### PR TITLE
Only invoke callback once

### DIFF
--- a/async/07-async.js
+++ b/async/07-async.js
@@ -7,7 +7,12 @@ module.exports = function (tasks, cb) {
     var task = tasks[taskName]
 
     task(function (er, taskResult) {
-      if (er && !errd) {
+      if (errd) {
+        return
+      }
+      
+      if (er) {
+        errd = true
         return cb(er)
       }
 


### PR DESCRIPTION
If I run the following in the `async` directory:

``` javascript
var async = require("./07-async")

var tasks = {
  profile: function (cb) {
    cb(new Error('profile failed'))
  },
  promos: function (cb) {
    cb(new Error('promos failed'))
  },
  results: function (cb) {
    cb(new Error('results failed'))
  }
}

async(tasks, function respond (er) {
  if (er) {
    return console.info('error!', er)
  }

  console.info('no error!')
})
```

the output is:

```
$ node test.js
error! [Error: profile failed]
error! [Error: promos failed]
error! [Error: results failed]
```

The callback passed to the `async` function is invoked multiple times because the value of the `errd` variable in `07-async.js` never changes.

This PR updates `errd` so subsequent errors/successes do not cause the callback to be invoked again.

The output is then:

```
$ node test.js
error! [Error: profile failed]
```
